### PR TITLE
Added create subscriber endpoint support to attest

### DIFF
--- a/src/Integrity/Attestation.php
+++ b/src/Integrity/Attestation.php
@@ -13,12 +13,13 @@ namespace Mobbex\Integrity;
  * The first argument is the plugin's GitHub repo name and the second its
  * installation directory. Nothing else is platform specific: this class
  * registers itself as a header provider and attaches x-integrity-* to every
- * checkout request \Mobbex\Api makes.
+ * checkout creation and subscriber creation request \Mobbex\Api makes — see
+ * attests() for exactly which ones.
  *
  * Flow: ask the API for a challenge, then attach two values — an HMAC over the
  * byte ranges the server drew for this request, and a sum over the whole
  * release. The server recomputes both from the published artifact and refuses
- * the checkout when they differ.
+ * the request when they differ.
  *
  * Both are needed. The drawn ranges make the value impossible to precompute,
  * which a static checksum never was: it could be copied straight out of the
@@ -302,8 +303,16 @@ class Attestation
     /**
      * Whether this request should carry an attestation.
      *
-     * Only checkout creation. Attesting every call would multiply the cost for
-     * no gain, and the challenge request itself must never be attested.
+     * Checkout creation, plus subscriber creation (Mobbex\Modules\Subscriber).
+     * Attesting every call would multiply the cost for no gain, and the
+     * challenge request itself must never be attested.
+     *
+     * The subscriber pattern is anchored and method-gated on purpose: the same
+     * URI shape, subscriptions/{uid}/subscriber/{uid}, is also hit with GET to
+     * read a subscriber's executions, and sibling writes (execute a charge,
+     * activate/suspend, modify the subscription itself) add or change path
+     * segments. Only the exact create call — POST, nothing after the trailing
+     * uid — is in scope; the rest are deliberately left for later.
      *
      * @param array $data
      *
@@ -314,7 +323,15 @@ class Attestation
         if (empty(self::$platform) || empty(self::$rootDir) || empty(self::$version))
             return false;
 
-        return !empty($data['uri']) && strpos($data['uri'], 'checkout') !== false;
+        if (empty($data['uri']))
+            return false;
+
+        if (strpos($data['uri'], 'checkout') !== false)
+            return true;
+
+        return !empty($data['method'])
+            && strtoupper($data['method']) === 'POST'
+            && preg_match('#^subscriptions/[^/]+/subscriber/[^/]+$#', $data['uri']) === 1;
     }
 
     /**

--- a/tests/IntegrityTest.php
+++ b/tests/IntegrityTest.php
@@ -177,8 +177,9 @@ class IntegrityTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
-     * Only checkout creation is attested. Attesting every call would multiply
-     * the cost for nothing, and the challenge request itself must never be.
+     * Only checkout and subscriber creation are attested. Attesting every call
+     * would multiply the cost for nothing, and the challenge request itself
+     * must never be.
      */
     public function testOnlyChecksoutRequestsAreAttested()
     {
@@ -186,6 +187,53 @@ class IntegrityTest extends \PHPUnit\Framework\TestCase
 
         $this->assertSame([], Attestation::getHeaders(['uri' => 'sources']));
         $this->assertSame([], Attestation::getHeaders([]));
+    }
+
+    /**
+     * Mobbex\Modules\Subscriber posts to subscriptions/{uid}/subscriber/{uid}.
+     * That exact call must attest, same as checkout, since it also provisions
+     * a paying object.
+     */
+    public function testSubscriberCreationIsAttested()
+    {
+        Attestation::init('prestashop', __DIR__, '1.0.0');
+
+        $headers = Attestation::getHeaders([
+            'method' => 'POST',
+            'uri'    => 'subscriptions/sub1/subscriber/usr1',
+        ]);
+
+        $this->assertContains('x-integrity-mode: static', $headers);
+    }
+
+    /**
+     * Everything else in the subscription domain shares the same URI prefix,
+     * and one case — reading a subscriber's executions — shares the exact same
+     * URI as creation, differing only by verb. None of these may attest: the
+     * pattern must stay anchored to the literal create call, not just "smells
+     * like a subscriber URI".
+     *
+     * @dataProvider subscriptionUrisNotInScopeProvider
+     */
+    public function testOtherSubscriptionRequestsAreNotAttested($data)
+    {
+        Attestation::init('prestashop', __DIR__, '1.0.0');
+
+        $this->assertSame([], Attestation::getHeaders($data));
+    }
+
+    public function subscriptionUrisNotInScopeProvider(): array
+    {
+        return [
+            'search_execution (same URI, GET)'  => [['method' => 'GET',  'uri' => 'subscriptions/sub1/subscriber/usr1']],
+            'execute_charge'                     => [['method' => 'POST', 'uri' => 'subscriptions/sub1/subscriber/usr1/execution']],
+            'activate/suspend action'            => [['method' => 'POST', 'uri' => 'subscriptions/sub1/subscriber/usr1/action/activate']],
+            'retry_charge action'                => [['method' => 'GET',  'uri' => 'subscriptions/sub1/subscriber/usr1/execution/eid1/action/retry']],
+            'search_subscriber (query string)'   => [['method' => 'GET',  'uri' => 'subscriptions/sub1/subscriber?page=0&search=x']],
+            // Same URI shape as modify_subscription: creating or updating the
+            // subscription itself is out of scope for this fix.
+            'subscription creation/modification' => [['method' => 'POST', 'uri' => 'subscriptions/sub1']],
+        ];
     }
 
     /**


### PR DESCRIPTION
### **IMPORTANTE: depende de la siguiente PR: https://github.com/sugaway/payments/pull/172**


Se añade validacion de integridad a las request del endpoint de creacion de subscriptores de la API para poder dar soporte a la en los plugins de subscripciones.

Se optó por este endpoint y no el de sources porque tenemos mayor control en la creacion de la request. Sources se va por redirect